### PR TITLE
Fix NameError exception (#14).

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -530,7 +530,7 @@ end
 def spec(gem_dir)
   files = Dir.glob("#{gem_dir}/*.gemspec")
   unless files.count == 1
-    error("Unable to select a gemspec #{gem_dir}")
+    error("Unable to select a gemspec in #{gem_dir}")
   end
   spec_path = files.first
   spec = Gem::Specification::load(spec_path.to_s)


### PR DESCRIPTION
At least it won't be a ruby syntax error, but we still need to fix the case of the 'shared' repo missing a gemspec and thus making the `error()` to occur

(see also CocoaPods/Rainforest#14 & CocoaPods/shared#2)
