### PR TITLE
Remove non-gem repo from list of gem repos

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,13 +16,15 @@ GEM_REPOS = %w[
   cocoapods-plugins
   cocoapods-podfile_info
   cocoapods-try
-  shared
 ]
 
 # @return [Array<String>] The list of the repos which should be cloned by
 #         default.
 #
-DEFAULT_REPOS = GEM_REPOS + %w( pod-template )
+DEFAULT_REPOS = GEM_REPOS + %w[
+  pod-template
+  shared
+]
 
 task :default => :status
 


### PR DESCRIPTION
The 'shared' repo was listed in GEM_REPOS, but it's not a gem so there
was breakage in the rake tasks that operate on the set of gem repos...

Moved it to DEFAULT_REPOS with pod-template.
