### PR TITLE
Added explicit UTF8 string encoding to Rakefile.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+#encoding: utf-8 
 
 # @return [Array<String>] The list of the names of the CocoaPods repositories
 #         which store a gem or are related to the development of the gems.


### PR DESCRIPTION
Was getting the following error:

```
 rake bootstrap --trace
rake aborted!
rake aborted!
ArgumentError: invalid byte sequence in US-ASCII
```

Found the answer [here](http://stackoverflow.com/questions/17031651/invalid-byte-sequence-in-us-ascii-argument-error-when-i-run-rake-dbseed-in-ra). Seems to work. 
