### PR TITLE
[Rakefile] Let unshallowed repos fetch all branches

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -92,6 +92,11 @@ begin
     title 'Unshallowing gem repositories'
     repos.each do |dir|
       Dir.chdir(dir) do
+        # Shallow clones are setup so that they fetch only master by default
+        subtitle "Overwrite fetch configuration"
+        system('git', 'config', '--set', '--local',
+               'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*')
+
         subtitle "Unshallowing #{dir}"
         system('git', 'fetch', '--unshallow')
       end


### PR DESCRIPTION
I got a fresh Rainforest clone trying to get a release out of the door after I realized that mine has grown weeds. Unfortunately I did a shallow clone initially, which is not really usable for that task as we have now stable branches since the release of 1.0. So I needed to unshallow them, which turned out to be not enough. In addition the default refs to fetch for the `origin` need to be updated. For reference: A shallow clone is setup to fetch by default only `+refs/heads/master:refs/remotes/origin/master` in the config as found in the key `remote.origin.fetch`. This value takes place of the optional `<refspec>` argument of `git-fetch`, which can be provided if the remote was specified, unless another value is specified.

/c @segiddins 