### PR TITLE
Fix bootstrap task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,7 +114,7 @@ begin
     rakefile_repos.each do |dir|
       Dir.chdir(dir) do
         subtitle "Bootstrapping #{dir}"
-        sh 'rake --no-search bootstrap' if rake_task?('bootstrap', :allow_bundler => false)
+        sh 'rake --no-search bootstrap' if rake_task?('bootstrap')
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1019,6 +1019,7 @@ end
 #         task with the given name.
 #
 def rake_task?(task, allow_bundler: true)
+  `bundle check || bundle install`
   command = "rake --no-search --tasks '#{task}'"
   if allow_bundler
     begin


### PR DESCRIPTION
Using a fresh installation of Ruby 2.0.0p648 through rvm, so empty gemset, the bootstrap task fails with the following stack trace: 

```
--------------------------------------------------------------------------------
Bootstrapping all the repositories
--------------------------------------------------------------------------------

Bootstrapping CLAide

Bootstrapping claide-completion
rake --no-search bootstrap
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/bin/bundle

--------------------------------------------------------------------------------
Installing gems
--------------------------------------------------------------------------------

bundle install
Fetching gem metadata from https://rubygems.org/...........
Fetching version metadata from https://rubygems.org/..
Fetching dependency metadata from https://rubygems.org/.
Resolving dependencies...
Using rake 12.0.0
Installing ast 2.3.0
Installing bacon 1.2.0
Installing claide 1.0.1
Using claide-completion 1.0.2 from source at `.`
Installing docile 1.1.5
Installing json 2.0.3 with native extensions
Installing simplecov-html 0.10.0
Installing ffi 1.9.18 with native extensions
Installing rb-fsevent 0.9.8
Installing notify 0.5.2
Installing metaclass 0.0.4
Installing powerpack 0.1.1
Installing rainbow 2.2.1 with native extensions
Installing ruby-progressbar 1.8.1
Installing unicode-display_width 1.1.3
Using bundler 1.14.6
Installing parser 2.4.0.0
Installing prettybacon 0.0.2
Installing simplecov 0.13.0
Installing rb-inotify 0.9.8
Installing rb-kqueue 0.2.4
Installing mocha 1.2.1
Installing rubocop 0.48.0
Installing codeclimate-test-reporter 1.0.8
Installing listen 1.3.1
Installing mocha-on-bacon 0.2.3
Installing kicker 3.0.0
Bundle complete! 10 Gemfile dependencies, 28 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.

Bootstrapping CocoaPods
rake aborted!
Bundler::GemNotFound: Could not find rake-10.5.0 in any of the sources
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/spec_set.rb:87:in `block in materialize'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/spec_set.rb:80:in `map!'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/spec_set.rb:80:in `materialize'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/definition.rb:176:in `specs'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/definition.rb:235:in `specs_for'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/definition.rb:224:in `requested_specs'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/runtime.rb:118:in `block in definition_method'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/runtime.rb:19:in `setup'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler.rb:100:in `setup'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/bundler-1.14.6/lib/bundler/setup.rb:20:in `<top (required)>'
/Users/ruenzuo/GitHub/CocoaPods/Rainforest/CocoaPods/Rakefile:42:in `<top (required)>'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/bin/ruby_executable_hooks:15:in `eval'
/Users/ruenzuo/.rvm/gems/ruby-2.0.0-p648/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```

Looks like at some point [bundler was added to the required gems](https://github.com/CocoaPods/CocoaPods/blob/master/Rakefile#L41-L42) for that Rakefile, using bundler to run along the bootstrap task fixes this problem.

Because of this change, a `bundle check || bundle install` is required before running the rake task.