### PR TITLE
Fix the .github_access_token file is not read when fetching repos

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -907,6 +907,8 @@ def changelog_for_repo(repo, version)
 end
 
 def github_access_token
+  require 'pathname'
+
   Pathname('.github_access_token').expand_path.read.strip
 rescue
   nil


### PR DESCRIPTION
When executing `rake bootstrap`, which will fetch repos, the `.github_access_token` file is not read even if it exists in the root of this repo.

The reason is that the `Pathname` method isn't working in the `github_access_token` method.
Inserting `require 'pathname'` line right before invoking it fixes this issue.