### PR TITLE
make it clear that this repo requires updating and shouldn't be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# This repo needs updating.
+For most contributions you can just fork https://github.com/CocoaPods/CocoaPods instead. Don't attempt `rake bootstrap`. You could run into all sorts of ruby and rake versioning issues. 
+
 # CocoaPods Rainforest
 
 [![Build Status](https://img.shields.io/travis/CocoaPods/Rainforest/master.svg?style=flat)](https://travis-ci.org/CocoaPods/Rainforest)


### PR DESCRIPTION
While I'm very happy with the days spent learning ruby, rake, rbenv, bundler and how to fix environmental issues. I think being loud and clear that the repo needs an update can save future dev time. 

@dnkoutso's [comment](https://github.com/CocoaPods/Rainforest/issues/89#issuecomment-752263648) on the issue I opened:

> that probably needs updating to be honest.

